### PR TITLE
fix(dfim): restore turbine-driven sizing calculations

### DIFF
--- a/docs/development/pr-78-integration.md
+++ b/docs/development/pr-78-integration.md
@@ -79,7 +79,9 @@ changes PMSM and SyRM prices and is not inherently related to adding DFIM.
 Proposed resolution: restore existing behavior for current machine types and
 introduce an explicit DFIM rule if its pricing differs.
 
-Status: **Resolved in working tree; existing behavior restored**
+Status: **Resolved in working tree; existing behavior is retained for SCIM,
+PMSM, and SyRM, while DFIM retains Stian's base-price rule without the
+efficiency-class premium**
 
 #### 2. Cooling price coefficients contradict their documentation
 
@@ -90,7 +92,9 @@ prices.
 Proposed resolution: restore the old values unless an engineering source
 supports changing both the values and documentation.
 
-Status: **Resolved in working tree; documented coefficients restored**
+Status: **Resolved in working tree; documented coefficients are retained for
+existing machine types, while Stian's IC411/IP54 and IC416/IP54 coefficients are
+scoped to DFIM**
 
 #### 3. Selecting DFIM initially produces no converter candidates
 
@@ -485,8 +489,8 @@ using a doubly-fed induction machine as a generator: turbine input,
 gearbox-referred inertia, wound-rotor machine, rotor-side and grid-side
 converters, DC link, transformer, grid connection, controls, and measurements.
 The use of "DFIG" in the MathWorks block description is compatible with the
-application's "DFIM" machine terminology: DFIM describes the machine, while
-DFIG describes its generator operation.
+application's "DFIM" machine terminology: DFIM describes the machine, while DFIG
+describes its generator operation.
 
 The model was saved with MATLAB/Simulink R2024b and uses Specialized Power
 Systems/Simscape Electrical blocks. The required MATLAB release, products, and
@@ -502,11 +506,11 @@ detection, this can remove the first parameter from the data, make `Var2`
 unavailable, shift all assignments, or leave only fourteen data rows for the
 fifteen accesses.
 
-This should be reproduced in the supported MATLAB release before validation.
-The preferred eventual contract is an explicit header such as
-`Name,Value,Unit`, with parameters retrieved and validated by name. The minimum
-possible correction would be an explicit headerless import, but that would
-retain the fragile dependence on row order.
+This should be reproduced in the supported MATLAB release before validation. The
+preferred eventual contract is an explicit header such as `Name,Value,Unit`,
+with parameters retrieved and validated by name. The minimum possible correction
+would be an explicit headerless import, but that would retain the fragile
+dependence on row order.
 
 ### Units and parameter contract
 
@@ -533,8 +537,8 @@ source, derivation, calibration case, or applicability range:
 - the 1% copper-loss assumption and equal split between stator and rotor;
 - leakage and magnetizing coefficients used to estimate the machine model;
 - the `1.634` DC-link-voltage multiplier;
-- aerodynamic constants `Cp = 0.4` and air density `1.225 kg/m^3` in the
-  MATLAB cut-in calculation;
+- aerodynamic constants `Cp = 0.4` and air density `1.225 kg/m^3` in the MATLAB
+  cut-in calculation;
 - the empirical cut-out wind-speed formula;
 - the turbine-inertia scaling formula;
 - fixed machine friction `0.01 pu`;
@@ -559,8 +563,8 @@ requires confirmation.
   workflow can fail when the three browser downloads are stored or opened from
   different locations.
 - The MATLAB script uses `clear`, `clc`, and the base workspace, and prints the
-  imported table. A future loader function returning a parameter structure, or
-  a `Simulink.SimulationInput`, would be safer and testable.
+  imported table. A future loader function returning a parameter structure, or a
+  `Simulink.SimulationInput`, would be safer and testable.
 - The script only loads parameters; it does not locate, open, configure, or run
   the Simulink model. The expected user sequence should be documented.
 - The model display labels `Te [kN]` and `Q [kW]` appear dimensionally wrong.
@@ -705,15 +709,16 @@ git diff --check
 Add durable decisions here. Include the date, decision, rationale, source or
 evidence, and participants when relevant.
 
-| Date       | Decision                                                          | Rationale / evidence                                                                                                 | Status      |
-| ---------- | ----------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- | ----------- |
-| 2026-08-10 | Keep current dependency versions rather than PR #78's versions    | The dependency work is newer and independent of the feature                                                          | Proposed    |
-| 2026-08-10 | Do not merge PR #78 unchanged                                     | Static review found correctness defects and unvalidated shared-model changes                                         | Proposed    |
-| 2026-08-10 | Preserve the original wind inputs, defaults, and topology results | Stian's scope is adding DFIM, not changing existing topologies; rotor diameter and wind speed are derived for export | Accepted    |
-| 2026-08-11 | Apply a complete DFIM starter case when DFIM is selected          | This follows the existing dependent-default pattern and gives both supported topologies valid candidates             | Accepted    |
-| 2026-08-11 | Keep the planned 7100 kW DFIM catalogue rating                    | The rating was intentionally added; the candidate boundary was aligned from 7000 to 7100 kW                          | Implemented |
-| 2026-08-11 | Defer numerical golden and export tests until human validation    | Current empirical coefficients and the external MATLAB/Simulink contract do not yet provide trusted expected values  | Accepted    |
-| 2026-08-11 | Do not preserve the former flat component-documentation URLs      | The canonical directory routes are working and backward-compatible redirects are not required                        | Accepted    |
+| Date       | Decision                                                          | Rationale / evidence                                                                                                        | Status              |
+| ---------- | ----------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- | ------------------- |
+| 2026-08-10 | Keep current dependency versions rather than PR #78's versions    | The dependency work is newer and independent of the feature                                                                 | Proposed            |
+| 2026-08-10 | Do not merge PR #78 unchanged                                     | Static review found correctness defects and unvalidated shared-model changes                                                | Proposed            |
+| 2026-08-10 | Preserve the original wind inputs, defaults, and topology results | Existing machine types retain this behavior; superseded for explicitly selected DFIM by the 2026-08-12 decision             | Superseded for DFIM |
+| 2026-08-11 | Apply a complete DFIM starter case when DFIM is selected          | This follows the existing dependent-default pattern and gives both supported topologies valid candidates                    | Accepted            |
+| 2026-08-11 | Keep the planned 7100 kW DFIM catalogue rating                    | The rating was intentionally added; the candidate boundary was aligned from 7000 to 7100 kW                                 | Implemented         |
+| 2026-08-11 | Defer numerical golden and export tests until human validation    | Current empirical coefficients and the external MATLAB/Simulink contract do not yet provide trusted expected values         | Accepted            |
+| 2026-08-11 | Do not preserve the former flat component-documentation URLs      | The canonical directory routes are working and backward-compatible redirects are not required                               | Accepted            |
+| 2026-08-12 | Use Stian's aerodynamic wind calculation direction for DFIM       | The thesis simulation starts from rotor diameter and rated wind speed; a 75 m, 12 m/s turbine produces approximately 2.1 MW | Implemented         |
 
 ## Session log
 
@@ -911,6 +916,29 @@ evidence, and participants when relevant.
 - Node.js 24 TypeScript compilation and the direct Next.js production build
   pass. The focused DFIM browser suite passes all **8 tests** across Chromium
   and Firefox, including both download tests.
+
+### 2026-08-12 — Restore Stian's DFIM wind calculation direction
+
+- Traced the quoted thesis 2.1 MW simulation case to the wind calculation
+  direction introduced by Stian's PR.
+- Added a DFIM-specific wind model that accepts rotor diameter and rated wind
+  speed, then derives shaft power, blade speed, overspeed, and rated torque
+  using Stian's formulas and constants.
+- Kept the original blade-speed and torque inputs unchanged for SCIM, PMSM,
+  SyRM, and every topology where DFIM is unavailable.
+- Scoped Stian's DFIM machine-price rules to DFIM: its base price omits the
+  efficiency-class premium and uses the PR's IC411/IP54 and IC416/IP54 cooling
+  coefficients. Existing machine types retain their previous pricing rules.
+- Made parameter updates resolve the model for the new state before evaluating
+  calculated fields. Selecting DFIM now installs the 75 m, 12 m/s reference
+  case atomically, and later gearbox or converter edits do not change its wind
+  torque.
+- Added a reference regression for a 75 m rotor at 12 m/s: approximately 2104.1
+  kW shaft power, 21.39 rpm blade speed, and 939.42 kNm rated torque.
+- Added a browser regression that verifies the same values through the user
+  interface in Chromium and Firefox.
+- Node.js 24 TypeScript validation and all 20 Jest tests pass. All 12 focused
+  wind and DFIM browser tests pass across Chromium and Firefox.
 
 ## Next-session checklist
 

--- a/docs/development/pr-78-integration.md
+++ b/docs/development/pr-78-integration.md
@@ -937,6 +937,14 @@ evidence, and participants when relevant.
   kW shaft power, 21.39 rpm blade speed, and 939.42 kNm rated torque.
 - Added a browser regression that verifies the same values through the user
   interface in Chromium and Firefox.
+- Extended the browser regression to the complete thesis rotor reference in the
+  transformer topology: 75 m rotor, 12 m/s rated wind, 1.2 overspeed, 2104.1 kW,
+  21 rpm rated speed, 26 rpm overspeed, 939 kNm, and a 2.5 MW DFIM candidate.
+- The aggregate values in thesis Figure 6.6.2 are not used as golden assertions.
+  The figure comes from a saved system whose component selections are not
+  recorded in the thesis or final PR; selecting the current matching candidates
+  does not reproduce its price, efficiency, volume, footprint, or weight. Do not
+  change calculations to fit those totals without the original saved system.
 - Node.js 24 TypeScript validation and all 20 Jest tests pass. All 12 focused
   wind and DFIM browser tests pass across Chromium and Firefox.
 

--- a/src/app/(home)/systems/[kind]/Input.tsx
+++ b/src/app/(home)/systems/[kind]/Input.tsx
@@ -2,7 +2,7 @@
 
 import { withCandidates } from "@/model/sizing";
 import { createSystem, updateParam } from "@/model/store";
-import { System } from "@/model/system";
+import { customizeModel, getModel, System } from "@/model/system";
 import { useRouter } from "next/navigation";
 import { useContext, useState } from "react";
 import Candidates from "./Candidates";
@@ -65,7 +65,14 @@ export default function Input({
                   key={`${system.element}.${k}.${k == update.exclude ? "" : update.count}}`}
                   name={k}
                   handleChange={(v) => {
-                    const updated = updateParam(model, system, k, v);
+                    const updated = updateParam(
+                      model,
+                      system,
+                      k,
+                      v,
+                      (nextSystem) =>
+                        customizeModel(getModel(nextSystem.kind), nextSystem),
+                    );
                     const errors = model.validate
                       ? model.validate(updated)
                       : [];

--- a/src/model/__tests__/pr-78-integration.test.ts
+++ b/src/model/__tests__/pr-78-integration.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, test } from "@jest/globals";
 import { findCableComponent } from "../cable-sizing";
 import type { EMachineComponent } from "../emachine-component";
 import { getPartialEfficiency } from "../emachine-efficiency";
-import { isWithinDfimSpeedRange } from "../emachine-sizing";
+import {
+  calculateEMachinePrice,
+  isWithinDfimSpeedRange,
+} from "../emachine-sizing";
 import { DFIMConverterType } from "../fconverter";
 import {
   getConverterPowerFraction,
@@ -12,8 +15,17 @@ import { findGearbox } from "../gearbox-sizing";
 import { withCandidates } from "../sizing";
 import { createSystem, updateParam } from "../store";
 import { customizeModel, getModel } from "../system";
+import { calculateDfimWindPerformance } from "../wind";
 
 describe("PR #78 integration", () => {
+  test("reproduces the 2.1 MW DFIM wind calculation", () => {
+    const wind = calculateDfimWindPerformance(75, 12);
+
+    expect(wind.powerOnShaft).toBeCloseTo(2104.14, 2);
+    expect(wind.ratedSpeedOfBlades).toBeCloseTo(21.39, 2);
+    expect(wind.ratedTorque).toBeCloseTo(939.42, 2);
+  });
+
   test("ties DFIM converter rating and speed range to 30% slip", () => {
     expect(getConverterPowerFraction("DFIM")).toBe(0.3);
     expect(getConverterPowerFraction("SCIM")).toBe(1);
@@ -39,6 +51,46 @@ describe("PR #78 integration", () => {
       95;
 
     expect(getPartialEfficiency(pmsm, 0.5, 95)).toBeCloseTo(expectedAtHalfLoad);
+  });
+
+  test("scopes the machine pricing rules to DFIM", () => {
+    const machine = {
+      type: "SCIM",
+      ratedPower: 1000,
+      ratedSynchSpeed: 1500,
+    } as Parameters<typeof calculateEMachinePrice>[1];
+    const voltage = {
+      value: 660,
+      min: 594,
+      max: 726,
+      type: "LV",
+    } as const;
+    const price = (
+      type: "SCIM" | "DFIM",
+      efficiencyClass: "IE2" | "IE3",
+      cooling: "IC411" | "IC416",
+    ) =>
+      calculateEMachinePrice(
+        voltage,
+        { ...machine, type },
+        10_000,
+        "IP54/55",
+        "cast iron",
+        "B3",
+        efficiencyClass,
+        cooling,
+      );
+
+    expect(price("DFIM", "IE3", "IC411")).toBe(price("DFIM", "IE2", "IC411"));
+    expect(price("SCIM", "IE3", "IC411")).toBeGreaterThan(
+      price("SCIM", "IE2", "IC411"),
+    );
+    expect(price("DFIM", "IE2", "IC416")).toBeGreaterThan(
+      price("DFIM", "IE2", "IC411"),
+    );
+    expect(price("SCIM", "IE2", "IC411")).toBeGreaterThan(
+      price("SCIM", "IE2", "IC416"),
+    );
   });
 
   test("extends the gearbox torque catalog only for DFIM", () => {
@@ -131,13 +183,16 @@ describe("PR #78 integration", () => {
       system,
       "type",
       "DFIM",
+      (nextSystem) => customizeModel(getModel(nextSystem.kind), nextSystem),
     );
     const customized = customizeModel(model, updated);
 
     expect(updated.input.fconverter.type).toBe(DFIMConverterType[0]);
     expect(updated.input.fconverter.gridSideFilter).toBe("sin");
     expect(updated.input.emachine.protection).toBe("IP54/55");
-    expect(updated.input.wind.ratedTorque).toBe(400);
+    expect(updated.input.wind.rotorDiameter).toBe(75);
+    expect(updated.input.wind.ratedWindSpeed).toBe(12);
+    expect(updated.input.wind.ratedTorque).toBeCloseTo(939.42, 2);
     expect(updated.input.gearbox).toMatchObject({
       numberOfStages: 2,
       stage1Type: "helical",
@@ -148,6 +203,63 @@ describe("PR #78 integration", () => {
     expect(customized.input.fconverter.params.type.options).toEqual(
       DFIMConverterType,
     );
+    expect(typeof customized.input.wind.params.rotorDiameter.value).toBe(
+      "number",
+    );
+    expect(typeof customized.input.wind.params.ratedWindSpeed.value).toBe(
+      "number",
+    );
+    expect(typeof customized.input.wind.params.ratedSpeedOfBlades.value).toBe(
+      "function",
+    );
+    expect(typeof customized.input.wind.params.ratedTorque.value).toBe(
+      "function",
+    );
+  });
+
+  test("uses the DFIM wind inputs only after DFIM is selected", () => {
+    const model = getModel("wind-gb-fc");
+    let system = createSystem(model);
+
+    const originalModel = customizeModel(model, system);
+    expect(typeof originalModel.input.wind.params.ratedTorque.value).toBe(
+      "number",
+    );
+    expect(typeof originalModel.input.wind.params.rotorDiameter.value).toBe(
+      "function",
+    );
+
+    system.element = "emachine";
+    system = updateParam(originalModel, system, "type", "DFIM", (nextSystem) =>
+      customizeModel(getModel(nextSystem.kind), nextSystem),
+    );
+
+    expect(system.input.wind.rotorDiameter).toBe(75);
+    expect(system.input.wind.ratedWindSpeed).toBe(12);
+    expect(system.input.wind.powerOnShaft).toBeCloseTo(2104.14, 2);
+    expect(system.input.wind.ratedTorque).toBeCloseTo(939.42, 2);
+
+    const torqueAfterSelection = system.input.wind.ratedTorque;
+    system.element = "gearbox";
+    const dfimModelAfterSelection = customizeModel(model, system);
+    system = updateParam(
+      dfimModelAfterSelection,
+      system,
+      "stage1Ratio",
+      8,
+      (nextSystem) => customizeModel(getModel(nextSystem.kind), nextSystem),
+    );
+    expect(system.input.wind.ratedTorque).toBeCloseTo(torqueAfterSelection);
+
+    system.element = "wind";
+    let dfimModel = customizeModel(model, system);
+    system = updateParam(dfimModel, system, "rotorDiameter", 75);
+    dfimModel = customizeModel(model, system);
+    system = updateParam(dfimModel, system, "ratedWindSpeed", 12);
+
+    expect(system.input.wind.powerOnShaft).toBeCloseTo(2104.14, 2);
+    expect(system.input.wind.ratedSpeedOfBlades).toBeCloseTo(21.39, 2);
+    expect(system.input.wind.ratedTorque).toBeCloseTo(939.42, 2);
   });
 
   test.each(["wind-gb-fc", "wind-gb-fc-tr"] as const)(
@@ -162,6 +274,7 @@ describe("PR #78 integration", () => {
         system,
         "type",
         "DFIM",
+        (nextSystem) => customizeModel(getModel(nextSystem.kind), nextSystem),
       );
       const emachineCandidates = updated.candidates.emachine ?? [];
       const withMachine = withCandidates({

--- a/src/model/emachine-sizing.ts
+++ b/src/model/emachine-sizing.ts
@@ -178,7 +178,7 @@ export function findEmCandidates(
                   if (typeof shaftHeight == "undefined") {
                     throw new Error("shaftHeight not found");
                   }
-                  const price = getPrice(
+                  const price = calculateEMachinePrice(
                     ratedVoltageY,
                     typeSpeedTorque,
                     weight,
@@ -443,7 +443,7 @@ function getPriceIncrease(
   }
 }
 
-function getPrice(
+export function calculateEMachinePrice(
   ratedVoltageY: VoltageY,
   typeSpeedTorque: TypeSpeedTorque,
   weight: number,
@@ -465,8 +465,14 @@ function getPrice(
       getK6(frameMaterial) *
       getK7(mounting) *
       K9) /
-      getK14(cooling, protection)) *
+      getK14(typeSpeedTorque.type, cooling, protection)) *
     Math.pow(weight / 1000, a);
+
+  // The DFIM price model does not apply the efficiency-class premium.
+  // Keep the established premium for every pre-existing machine type.
+  if (typeSpeedTorque.type == "DFIM") {
+    return price;
+  }
 
   return (
     price +
@@ -486,6 +492,7 @@ function getPrice(
 // K14 = 0,85 for IC71W
 
 function getK14(
+  type: EMachineTypeAlias,
   cooling: EMachineCoolingType,
   protection: EMachineProtectionType,
 ) {
@@ -493,14 +500,17 @@ function getK14(
     case "IC411":
       switch (protection) {
         case "IP54/55":
-          return 0.975;
+          // The DFIM model uses 1 for self-ventilation. The established
+          // coefficient remains unchanged for all pre-existing machine types.
+          return type == "DFIM" ? 1 : 0.975;
         case "IP21/23":
           return 0.9;
       }
     case "IC416":
       switch (protection) {
         case "IP54/55":
-          return 1;
+          // The DFIM model uses 0.975 for forced ventilation.
+          return type == "DFIM" ? 0.975 : 1;
         case "IP21/23":
           return 0.925;
       }

--- a/src/model/emachine.tsx
+++ b/src/model/emachine.tsx
@@ -97,7 +97,8 @@ export const EMachineElement: SystemElement<EMachine> = {
               ? {
                   wind: {
                     ...system.input.wind,
-                    ratedTorque: 400,
+                    rotorDiameter: 75,
+                    ratedWindSpeed: 12,
                   },
                   gearbox: {
                     ...system.input.gearbox,

--- a/src/model/store.ts
+++ b/src/model/store.ts
@@ -98,6 +98,7 @@ export function updateParam(
   system: System,
   paramName: string,
   value: any,
+  resolveModel?: (system: System) => SystemModel,
 ): System {
   const withParamValue: System = {
     ...system,
@@ -117,7 +118,12 @@ export function updateParam(
     ) ?? withParamValue;
   const withModelUpdate = model.update?.(withParamUpdate) ?? withParamUpdate;
 
-  const input = updateSystemInput(model, withModelUpdate.input);
+  // A parameter update can change which customized model applies (for example,
+  // selecting DFIM changes the wind calculation direction). Resolve that model
+  // before evaluating calculated fields so the transition is completed in one
+  // update rather than after the user's next edit.
+  const calculationModel = resolveModel?.(withModelUpdate) ?? model;
+  const input = updateSystemInput(calculationModel, withModelUpdate.input);
   const withCalculatedParams = {
     ...withModelUpdate,
     input,

--- a/src/model/system.tsx
+++ b/src/model/system.tsx
@@ -18,6 +18,7 @@ import { Grid } from "./grid";
 import { PumpFc, PumpFcTr, PumpGbFc, PumpGbFcTr } from "./pump-system";
 import { SystemParamsType } from "./system-params";
 import { WinchFc, WinchFcTr, WinchGbFc, WinchGbFcTr } from "./winch-system";
+import { DfimWindElement } from "./wind";
 import { WindFc, WindFcTr, WindGbFc, WindGbFcTr } from "./wind-system";
 
 export type ParamType = "text" | "number";
@@ -194,6 +195,7 @@ function customizeSystemModel(
         ...model,
         input: {
           ...model.input,
+          wind: DfimWindElement,
           fconverter: {
             ...fconverter,
             icon: dfimFConverter3LIcon,
@@ -209,6 +211,7 @@ function customizeSystemModel(
         ...model,
         input: {
           ...model.input,
+          wind: DfimWindElement,
           fconverter: {
             ...fconverter,
             icon: dfimFConverterML4QIcon,
@@ -224,6 +227,7 @@ function customizeSystemModel(
       ...model,
       input: {
         ...model.input,
+        wind: DfimWindElement,
         fconverter: {
           ...fconverter,
           icon: dfimFConverter2LIcon,

--- a/src/model/wind.ts
+++ b/src/model/wind.ts
@@ -17,6 +17,26 @@ const Cp = 0.45;
 const TSR = 7;
 const airDensity = 1.225;
 
+export function calculateDfimWindPerformance(
+  rotorDiameter: number,
+  ratedWindSpeed: number,
+) {
+  const powerOnShaft =
+    (((Cp * airDensity) / 2) *
+      ratedWindSpeed ** 3 *
+      Math.PI *
+      (rotorDiameter / 2) ** 2) /
+    1000;
+  const ratedSpeedOfBlades =
+    (ratedWindSpeed * TSR * 60) / (Math.PI * rotorDiameter);
+
+  return {
+    powerOnShaft,
+    ratedSpeedOfBlades,
+    ratedTorque: (powerOnShaft / ratedSpeedOfBlades) * 9.55,
+  };
+}
+
 function deriveWindDimensions(
   ratedSpeedOfBlades: number,
   powerOnShaft: number,
@@ -89,6 +109,52 @@ export const WindElement: SystemElement<Wind> = {
         deriveWindDimensions(wind.ratedSpeedOfBlades, wind.powerOnShaft)
           .ratedWindSpeed,
       advanced: true,
+    },
+  },
+};
+
+/**
+ * The DFIM model starts with turbine dimensions and derives the mechanical
+ * operating point used for gearbox and machine sizing. Existing machine types
+ * retain DriveConstructor's original speed-and-torque input direction.
+ */
+export const DfimWindElement: SystemElement<Wind> = {
+  ...WindElement,
+  params: {
+    rotorDiameter: {
+      label: "Rotor diameter, m",
+      type: "number",
+      value: 75,
+      range: { min: 20, max: 200 },
+    },
+    ratedWindSpeed: {
+      label: "Rated wind speed, m/s",
+      type: "number",
+      value: 12,
+      range: { min: 5, max: 25 },
+    },
+    overSpeed: WindElement.params.overSpeed,
+    powerOnShaft: {
+      ...WindElement.params.powerOnShaft,
+      value: (wind) =>
+        calculateDfimWindPerformance(wind.rotorDiameter, wind.ratedWindSpeed)
+          .powerOnShaft,
+    },
+    ratedSpeedOfBlades: {
+      ...WindElement.params.ratedSpeedOfBlades,
+      value: (wind) =>
+        calculateDfimWindPerformance(wind.rotorDiameter, wind.ratedWindSpeed)
+          .ratedSpeedOfBlades,
+    },
+    ratedTorque: {
+      ...WindElement.params.ratedTorque,
+      value: (wind) =>
+        calculateDfimWindPerformance(wind.rotorDiameter, wind.ratedWindSpeed)
+          .ratedTorque,
+    },
+    ratedSpeed: {
+      ...WindElement.params.ratedSpeed,
+      value: (wind) => wind.ratedSpeedOfBlades * wind.overSpeed,
     },
   },
 };

--- a/tests/dfim-defaults.spec.ts
+++ b/tests/dfim-defaults.spec.ts
@@ -42,6 +42,36 @@ for (const topology of ["wind-gb-fc", "wind-gb-fc-tr"] as const) {
   });
 }
 
+test("DFIM derives the 2.1 MW operating point from turbine inputs", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await page.getByTestId("wind").click();
+  await page.getByTestId("wind-gb-fc").click();
+
+  await page.getByTestId("emachine.<icon>").click();
+  await page.getByLabel("Type:").selectOption("DFIM");
+  await page.getByTestId("wind.<icon>").click();
+
+  await expect(page.getByLabel("Rotor diameter, m:")).toHaveValue("75");
+  await expect(page.getByLabel("Rated wind speed, m/s:")).toHaveValue("12");
+
+  await page.getByLabel("Rotor diameter, m:").fill("75");
+  await page.getByLabel("Rotor diameter, m:").press("Tab");
+  await page.getByLabel("Rated wind speed, m/s:").fill("12");
+  await page.getByLabel("Rated wind speed, m/s:").press("Tab");
+  await page.getByRole("button", { name: "More..." }).first().click();
+
+  await expect(page.getByLabel("Power on shaft, kW:")).toHaveValue("2104.1");
+  await expect(page.getByLabel("Rated speed of the blades, rpm:")).toHaveValue(
+    "21",
+  );
+  await expect(page.getByLabel("Rated torque, kNm:")).toHaveValue("939");
+  await expect(page.getByTestId("emachine[0].ratedPower")).toContainText(
+    "2500",
+  );
+});
+
 test("DFIM export actions fit a narrow viewport", async ({ page }) => {
   await page.setViewportSize({ width: 390, height: 844 });
   await page.goto("/");

--- a/tests/dfim-defaults.spec.ts
+++ b/tests/dfim-defaults.spec.ts
@@ -42,12 +42,12 @@ for (const topology of ["wind-gb-fc", "wind-gb-fc-tr"] as const) {
   });
 }
 
-test("DFIM derives the 2.1 MW operating point from turbine inputs", async ({
+test("DFIM matches the thesis 2.1 MW reference system", async ({
   page,
 }) => {
   await page.goto("/");
   await page.getByTestId("wind").click();
-  await page.getByTestId("wind-gb-fc").click();
+  await page.getByTestId("wind-gb-fc-tr").click();
 
   await page.getByTestId("emachine.<icon>").click();
   await page.getByLabel("Type:").selectOption("DFIM");
@@ -66,6 +66,7 @@ test("DFIM derives the 2.1 MW operating point from turbine inputs", async ({
   await expect(page.getByLabel("Rated speed of the blades, rpm:")).toHaveValue(
     "21",
   );
+  await expect(page.getByLabel("Overspeed, rpm:")).toHaveValue("26");
   await expect(page.getByLabel("Rated torque, kNm:")).toHaveValue("939");
   await expect(page.getByTestId("emachine[0].ratedPower")).toContainText(
     "2500",


### PR DESCRIPTION
Apply the rotor-diameter and rated-wind-speed calculation direction only when DFIM is selected, preserving the established speed-and-torque inputs for every existing machine type and unsupported topology.

Initialize DFIM with the validated 75 m, 12 m/s reference case and resolve customized models before recalculating parameters so selection is atomic and unrelated edits cannot change the operating point.

Scope the DFIM efficiency-premium and cooling-price coefficients without changing SCIM, PMSM, or SyRM pricing. Add unit and browser regressions for the 2.1 MW reference point, stable defaults, topology isolation, candidate availability, pricing behavior, exports, and narrow layouts.

Update the PR #78 integration record with the calculation decisions and verification results.