### PR TITLE
Use turbine-driven wind inputs across all topologies

### DIFF
--- a/docs/development/pr-78-integration.md
+++ b/docs/development/pr-78-integration.md
@@ -127,12 +127,13 @@ The wind model replaces entered blade speed and torque with rotor diameter and
 rated wind speed. Previously saved systems do not contain the new input fields,
 which may produce `NaN` values during recalculation.
 
-Final resolution: preserve the existing speed and torque inputs and make rotor
-diameter and rated wind speed additive calculated fields. Compatibility with
-pre-integration saved-system formats is explicitly out of scope, so no
-topology-specific load migration is required.
+Final resolution: use one static turbine-driven wind model for every wind
+topology. Rotor diameter and rated wind speed are inputs; shaft power, blade
+speed, maximum speed, and torque are calculated, while the overspeed factor
+remains an input. Compatibility with pre-integration saved-system formats is
+explicitly out of scope, so no load migration is required.
 
-Status: **Resolved by retaining the existing input model; migration removed**
+Status: **Resolved with the global static wind model; migration removed**
 
 #### 6. Direct-drive wind models expose a DFIM option that cannot produce a candidate
 
@@ -640,8 +641,9 @@ reference design remain validation follow-ups**
 - Decide whether migration of previously saved systems is required.
 - Add formula and boundary tests.
 
-Status: **Complete; existing speed/torque behavior is preserved, derived wind
-dimensions are additive, and legacy saved-format compatibility is out of scope**
+Status: **Complete; the static wind model uses rotor diameter and rated wind
+speed as inputs for all wind topologies, and legacy saved-format compatibility
+is out of scope**
 
 ### Stage 6: Add MATLAB/Simulink export
 
@@ -709,16 +711,16 @@ git diff --check
 Add durable decisions here. Include the date, decision, rationale, source or
 evidence, and participants when relevant.
 
-| Date       | Decision                                                          | Rationale / evidence                                                                                                        | Status              |
-| ---------- | ----------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- | ------------------- |
-| 2026-08-10 | Keep current dependency versions rather than PR #78's versions    | The dependency work is newer and independent of the feature                                                                 | Proposed            |
-| 2026-08-10 | Do not merge PR #78 unchanged                                     | Static review found correctness defects and unvalidated shared-model changes                                                | Proposed            |
-| 2026-08-10 | Preserve the original wind inputs, defaults, and topology results | Existing machine types retain this behavior; superseded for explicitly selected DFIM by the 2026-08-12 decision             | Superseded for DFIM |
-| 2026-08-11 | Apply a complete DFIM starter case when DFIM is selected          | This follows the existing dependent-default pattern and gives both supported topologies valid candidates                    | Accepted            |
-| 2026-08-11 | Keep the planned 7100 kW DFIM catalogue rating                    | The rating was intentionally added; the candidate boundary was aligned from 7000 to 7100 kW                                 | Implemented         |
-| 2026-08-11 | Defer numerical golden and export tests until human validation    | Current empirical coefficients and the external MATLAB/Simulink contract do not yet provide trusted expected values         | Accepted            |
-| 2026-08-11 | Do not preserve the former flat component-documentation URLs      | The canonical directory routes are working and backward-compatible redirects are not required                               | Accepted            |
-| 2026-08-12 | Use Stian's aerodynamic wind calculation direction for DFIM       | The thesis simulation starts from rotor diameter and rated wind speed; a 75 m, 12 m/s turbine produces approximately 2.1 MW | Implemented         |
+| Date       | Decision                                                          | Rationale / evidence                                                                                                                 | Status      |
+| ---------- | ----------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ | ----------- |
+| 2026-08-10 | Keep current dependency versions rather than PR #78's versions    | The dependency work is newer and independent of the feature                                                                          | Proposed    |
+| 2026-08-10 | Do not merge PR #78 unchanged                                     | Static review found correctness defects and unvalidated shared-model changes                                                         | Proposed    |
+| 2026-08-10 | Preserve the original wind inputs, defaults, and topology results | Superseded by the decision to use the turbine-driven model consistently across all wind topologies                                   | Superseded  |
+| 2026-08-11 | Apply a complete DFIM starter case when DFIM is selected          | This follows the existing dependent-default pattern and gives both supported topologies valid candidates                             | Accepted    |
+| 2026-08-11 | Keep the planned 7100 kW DFIM catalogue rating                    | The rating was intentionally added; the candidate boundary was aligned from 7000 to 7100 kW                                          | Implemented |
+| 2026-08-11 | Defer numerical golden and export tests until human validation    | Current empirical coefficients and the external MATLAB/Simulink contract do not yet provide trusted expected values                  | Accepted    |
+| 2026-08-11 | Do not preserve the former flat component-documentation URLs      | The canonical directory routes are working and backward-compatible redirects are not required                                        | Accepted    |
+| 2026-08-12 | Use the aerodynamic wind calculation direction globally           | A wind element has one definition regardless of machine selection; rotor diameter and rated wind speed determine its operating point | Implemented |
 
 ## Session log
 
@@ -917,22 +919,27 @@ evidence, and participants when relevant.
   pass. The focused DFIM browser suite passes all **8 tests** across Chromium
   and Firefox, including both download tests.
 
-### 2026-08-12 — Restore Stian's DFIM wind calculation direction
+### 2026-08-12 — Restore the turbine-driven wind calculation direction
 
 - Traced the quoted thesis 2.1 MW simulation case to the wind calculation
   direction introduced by Stian's PR.
-- Added a DFIM-specific wind model that accepts rotor diameter and rated wind
-  speed, then derives shaft power, blade speed, overspeed, and rated torque
-  using Stian's formulas and constants.
-- Kept the original blade-speed and torque inputs unchanged for SCIM, PMSM,
-  SyRM, and every topology where DFIM is unavailable.
+- Replaced the temporary DFIM-specific customization with one static wind model
+  used by every wind topology and machine type. It accepts rotor diameter and
+  rated wind speed, then derives shaft power, blade speed, overspeed, and rated
+  torque using the PR formulas and constants.
 - Scoped Stian's DFIM machine-price rules to DFIM: its base price omits the
   efficiency-class premium and uses the PR's IC411/IP54 and IC416/IP54 cooling
   coefficients. Existing machine types retain their previous pricing rules.
-- Made parameter updates resolve the model for the new state before evaluating
-  calculated fields. Selecting DFIM now installs the 75 m, 12 m/s reference
-  case atomically, and later gearbox or converter edits do not change its wind
-  torque.
+- Removed the model-transition resolver that was only needed by the temporary
+  DFIM-specific wind customization.
+- Chose rounded turbine defaults that reproduce the former mechanical sizing
+  points: 10.3 m, 7.7 m/s, and 1.2 overspeed for direct-drive topologies; 56.5
+  m, 8.5 m/s, and 1.2 overspeed for geared topologies. Selecting DFIM applies
+  its 75 m, 12 m/s, and 1.2 overspeed reference defaults without changing the
+  shared wind model.
+- Updated the direct-drive regression for the corrected 10.48 kW shaft power;
+  its existing machine and cable matches remain unchanged, while the correctly
+  sized frequency converter changes from 15 kW to 11 kW.
 - Added a reference regression for a 75 m rotor at 12 m/s: approximately 2104.1
   kW shaft power, 21.39 rpm blade speed, and 939.42 kNm rated torque.
 - Added a browser regression that verifies the same values through the user

--- a/src/app/(home)/systems/[kind]/Input.tsx
+++ b/src/app/(home)/systems/[kind]/Input.tsx
@@ -2,7 +2,7 @@
 
 import { withCandidates } from "@/model/sizing";
 import { createSystem, updateParam } from "@/model/store";
-import { customizeModel, getModel, System } from "@/model/system";
+import { System } from "@/model/system";
 import { useRouter } from "next/navigation";
 import { useContext, useState } from "react";
 import Candidates from "./Candidates";
@@ -65,14 +65,7 @@ export default function Input({
                   key={`${system.element}.${k}.${k == update.exclude ? "" : update.count}}`}
                   name={k}
                   handleChange={(v) => {
-                    const updated = updateParam(
-                      model,
-                      system,
-                      k,
-                      v,
-                      (nextSystem) =>
-                        customizeModel(getModel(nextSystem.kind), nextSystem),
-                    );
+                    const updated = updateParam(model, system, k, v);
                     const errors = model.validate
                       ? model.validate(updated)
                       : [];

--- a/src/model/__tests__/pr-78-integration.test.ts
+++ b/src/model/__tests__/pr-78-integration.test.ts
@@ -15,11 +15,11 @@ import { findGearbox } from "../gearbox-sizing";
 import { withCandidates } from "../sizing";
 import { createSystem, updateParam } from "../store";
 import { customizeModel, getModel } from "../system";
-import { calculateDfimWindPerformance } from "../wind";
+import { calculateWindPerformance } from "../wind";
 
 describe("PR #78 integration", () => {
   test("reproduces the 2.1 MW DFIM wind calculation", () => {
-    const wind = calculateDfimWindPerformance(75, 12);
+    const wind = calculateWindPerformance(75, 12);
 
     expect(wind.powerOnShaft).toBeCloseTo(2104.14, 2);
     expect(wind.ratedSpeedOfBlades).toBeCloseTo(21.39, 2);
@@ -183,7 +183,6 @@ describe("PR #78 integration", () => {
       system,
       "type",
       "DFIM",
-      (nextSystem) => customizeModel(getModel(nextSystem.kind), nextSystem),
     );
     const customized = customizeModel(model, updated);
 
@@ -217,22 +216,24 @@ describe("PR #78 integration", () => {
     );
   });
 
-  test("uses the DFIM wind inputs only after DFIM is selected", () => {
+  test("uses one turbine-driven wind model for every machine type", () => {
     const model = getModel("wind-gb-fc");
     let system = createSystem(model);
 
     const originalModel = customizeModel(model, system);
     expect(typeof originalModel.input.wind.params.ratedTorque.value).toBe(
-      "number",
-    );
-    expect(typeof originalModel.input.wind.params.rotorDiameter.value).toBe(
       "function",
     );
+    expect(typeof originalModel.input.wind.params.rotorDiameter.value).toBe(
+      "number",
+    );
+    expect(system.input.wind.rotorDiameter).toBe(56.5);
+    expect(system.input.wind.ratedWindSpeed).toBe(8.5);
+    expect(system.input.wind.powerOnShaft).toBeCloseTo(424.39, 2);
+    expect(system.input.wind.ratedTorque).toBeCloseTo(201.51, 2);
 
     system.element = "emachine";
-    system = updateParam(originalModel, system, "type", "DFIM", (nextSystem) =>
-      customizeModel(getModel(nextSystem.kind), nextSystem),
-    );
+    system = updateParam(originalModel, system, "type", "DFIM");
 
     expect(system.input.wind.rotorDiameter).toBe(75);
     expect(system.input.wind.ratedWindSpeed).toBe(12);
@@ -242,13 +243,7 @@ describe("PR #78 integration", () => {
     const torqueAfterSelection = system.input.wind.ratedTorque;
     system.element = "gearbox";
     const dfimModelAfterSelection = customizeModel(model, system);
-    system = updateParam(
-      dfimModelAfterSelection,
-      system,
-      "stage1Ratio",
-      8,
-      (nextSystem) => customizeModel(getModel(nextSystem.kind), nextSystem),
-    );
+    system = updateParam(dfimModelAfterSelection, system, "stage1Ratio", 8);
     expect(system.input.wind.ratedTorque).toBeCloseTo(torqueAfterSelection);
 
     system.element = "wind";
@@ -274,7 +269,6 @@ describe("PR #78 integration", () => {
         system,
         "type",
         "DFIM",
-        (nextSystem) => customizeModel(getModel(nextSystem.kind), nextSystem),
       );
       const emachineCandidates = updated.candidates.emachine ?? [];
       const withMachine = withCandidates({

--- a/src/model/emachine.tsx
+++ b/src/model/emachine.tsx
@@ -99,6 +99,7 @@ export const EMachineElement: SystemElement<EMachine> = {
                     ...system.input.wind,
                     rotorDiameter: 75,
                     ratedWindSpeed: 12,
+                    overSpeed: 1.2,
                   },
                   gearbox: {
                     ...system.input.gearbox,

--- a/src/model/store.ts
+++ b/src/model/store.ts
@@ -98,7 +98,6 @@ export function updateParam(
   system: System,
   paramName: string,
   value: any,
-  resolveModel?: (system: System) => SystemModel,
 ): System {
   const withParamValue: System = {
     ...system,
@@ -118,12 +117,7 @@ export function updateParam(
     ) ?? withParamValue;
   const withModelUpdate = model.update?.(withParamUpdate) ?? withParamUpdate;
 
-  // A parameter update can change which customized model applies (for example,
-  // selecting DFIM changes the wind calculation direction). Resolve that model
-  // before evaluating calculated fields so the transition is completed in one
-  // update rather than after the user's next edit.
-  const calculationModel = resolveModel?.(withModelUpdate) ?? model;
-  const input = updateSystemInput(calculationModel, withModelUpdate.input);
+  const input = updateSystemInput(model, withModelUpdate.input);
   const withCalculatedParams = {
     ...withModelUpdate,
     input,

--- a/src/model/system.tsx
+++ b/src/model/system.tsx
@@ -18,7 +18,6 @@ import { Grid } from "./grid";
 import { PumpFc, PumpFcTr, PumpGbFc, PumpGbFcTr } from "./pump-system";
 import { SystemParamsType } from "./system-params";
 import { WinchFc, WinchFcTr, WinchGbFc, WinchGbFcTr } from "./winch-system";
-import { DfimWindElement } from "./wind";
 import { WindFc, WindFcTr, WindGbFc, WindGbFcTr } from "./wind-system";
 
 export type ParamType = "text" | "number";
@@ -195,7 +194,6 @@ function customizeSystemModel(
         ...model,
         input: {
           ...model.input,
-          wind: DfimWindElement,
           fconverter: {
             ...fconverter,
             icon: dfimFConverter3LIcon,
@@ -211,7 +209,6 @@ function customizeSystemModel(
         ...model,
         input: {
           ...model.input,
-          wind: DfimWindElement,
           fconverter: {
             ...fconverter,
             icon: dfimFConverterML4QIcon,
@@ -227,7 +224,6 @@ function customizeSystemModel(
       ...model,
       input: {
         ...model.input,
-        wind: DfimWindElement,
         fconverter: {
           ...fconverter,
           icon: dfimFConverter2LIcon,

--- a/src/model/wind-system.tsx
+++ b/src/model/wind-system.tsx
@@ -8,7 +8,26 @@ import { SwitchElement } from "./switch";
 import { BaseSystem, Model } from "./system";
 import { Trafo, TrafoElement } from "./trafo";
 import { updateTrSystem } from "./trafo-system-utils";
-import { Wind, WindElement } from "./wind";
+import { gearedWindDefaults, Wind, WindElement } from "./wind";
+
+const GearedWindElement = {
+  ...WindElement,
+  params: {
+    ...WindElement.params,
+    rotorDiameter: {
+      ...WindElement.params.rotorDiameter,
+      value: gearedWindDefaults.rotorDiameter,
+    },
+    ratedWindSpeed: {
+      ...WindElement.params.ratedWindSpeed,
+      value: gearedWindDefaults.ratedWindSpeed,
+    },
+    overSpeed: {
+      ...WindElement.params.overSpeed,
+      value: gearedWindDefaults.overSpeed,
+    },
+  },
+};
 
 export type WindFc = BaseSystem & {
   kind: "wind-fc";
@@ -96,22 +115,7 @@ export const WindGbFcModel: Model<WindGbFc> = {
     </div>
   ),
   input: {
-    wind: {
-      ...WindElement,
-      params: {
-        ...WindElement.params,
-        ratedSpeedOfBlades: {
-          ...WindElement.params.ratedSpeedOfBlades,
-          value: 20,
-          range: { min: 10, max: 400 },
-        },
-        ratedTorque: {
-          ...WindElement.params.ratedTorque,
-          value: 200,
-          range: { min: 1, max: 2000 },
-        },
-      },
-    },
+    wind: GearedWindElement,
     gearbox: GearboxElement,
     emachine: { ...WindFcModel.input.emachine },
     cable: CableElement,

--- a/src/model/wind.ts
+++ b/src/model/wind.ts
@@ -17,7 +17,23 @@ const Cp = 0.45;
 const TSR = 7;
 const airDensity = 1.225;
 
-export function calculateDfimWindPerformance(
+// These turbine inputs reproduce the original direct-drive mechanical point:
+// 100 rpm blade speed, 120 rpm overspeed and 1 kNm torque.
+export const directDriveWindDefaults = {
+  rotorDiameter: 10.3,
+  ratedWindSpeed: 7.7,
+  overSpeed: 1.2,
+};
+
+// These inputs reproduce the original geared mechanical point:
+// 20 rpm blade speed, 24 rpm overspeed and 200 kNm torque.
+export const gearedWindDefaults = {
+  rotorDiameter: 56.5,
+  ratedWindSpeed: 8.5,
+  overSpeed: 1.2,
+};
+
+export function calculateWindPerformance(
   rotorDiameter: number,
   ratedWindSpeed: number,
 ) {
@@ -37,47 +53,25 @@ export function calculateDfimWindPerformance(
   };
 }
 
-function deriveWindDimensions(
-  ratedSpeedOfBlades: number,
-  powerOnShaft: number,
-) {
-  const speedFactor = (ratedSpeedOfBlades * Math.PI) / (TSR * 60);
-  const rotorDiameter = Math.pow(
-    (powerOnShaft * 1000 * 8) / (airDensity * Cp * Math.PI * speedFactor ** 3),
-    1 / 5,
-  );
-
-  return {
-    rotorDiameter,
-    ratedWindSpeed: speedFactor * rotorDiameter,
-  };
-}
-
 export const WindElement: SystemElement<Wind> = {
   icon,
   params: {
-    ratedSpeedOfBlades: {
-      label: "Rated speed of the blades, rpm",
+    rotorDiameter: {
+      label: "Rotor diameter, m",
       type: "number",
-      value: 100,
-      range: {
-        min: 30,
-        max: 400,
-      },
+      value: directDriveWindDefaults.rotorDiameter,
+      range: { min: 5, max: 200 },
     },
-    ratedTorque: {
-      label: "Rated torque, kNm",
+    ratedWindSpeed: {
+      label: "Rated wind speed, m/s",
       type: "number",
-      value: 1,
-      range: {
-        min: 0.1,
-        max: 100,
-      },
+      value: directDriveWindDefaults.ratedWindSpeed,
+      range: { min: 5, max: 25 },
     },
     overSpeed: {
       label: "Overspeed",
       type: "number",
-      value: 1.2,
+      value: directDriveWindDefaults.overSpeed,
       precision: 1,
       range: {
         min: 1,
@@ -85,76 +79,30 @@ export const WindElement: SystemElement<Wind> = {
         step: 0.05,
       },
     },
+    powerOnShaft: {
+      ...PowerOnShaftParam,
+      value: (wind) =>
+        calculateWindPerformance(wind.rotorDiameter, wind.ratedWindSpeed)
+          .powerOnShaft,
+    },
+    ratedSpeedOfBlades: {
+      label: "Rated speed of the blades, rpm",
+      type: "number",
+      value: (wind) =>
+        calculateWindPerformance(wind.rotorDiameter, wind.ratedWindSpeed)
+          .ratedSpeedOfBlades,
+    },
     ratedSpeed: {
       label: "Overspeed, rpm",
       type: "number",
       value: (wind) => wind.ratedSpeedOfBlades * wind.overSpeed,
     },
-    powerOnShaft: {
-      ...PowerOnShaftParam,
-      value: (wind) => (wind.ratedSpeed / 9.55) * wind.ratedTorque,
-    },
-    rotorDiameter: {
-      label: "Equivalent rotor diameter, m",
-      type: "number",
-      value: (wind) =>
-        deriveWindDimensions(wind.ratedSpeedOfBlades, wind.powerOnShaft)
-          .rotorDiameter,
-      advanced: true,
-    },
-    ratedWindSpeed: {
-      label: "Equivalent rated wind speed, m/s",
-      type: "number",
-      value: (wind) =>
-        deriveWindDimensions(wind.ratedSpeedOfBlades, wind.powerOnShaft)
-          .ratedWindSpeed,
-      advanced: true,
-    },
-  },
-};
-
-/**
- * The DFIM model starts with turbine dimensions and derives the mechanical
- * operating point used for gearbox and machine sizing. Existing machine types
- * retain DriveConstructor's original speed-and-torque input direction.
- */
-export const DfimWindElement: SystemElement<Wind> = {
-  ...WindElement,
-  params: {
-    rotorDiameter: {
-      label: "Rotor diameter, m",
-      type: "number",
-      value: 75,
-      range: { min: 20, max: 200 },
-    },
-    ratedWindSpeed: {
-      label: "Rated wind speed, m/s",
-      type: "number",
-      value: 12,
-      range: { min: 5, max: 25 },
-    },
-    overSpeed: WindElement.params.overSpeed,
-    powerOnShaft: {
-      ...WindElement.params.powerOnShaft,
-      value: (wind) =>
-        calculateDfimWindPerformance(wind.rotorDiameter, wind.ratedWindSpeed)
-          .powerOnShaft,
-    },
-    ratedSpeedOfBlades: {
-      ...WindElement.params.ratedSpeedOfBlades,
-      value: (wind) =>
-        calculateDfimWindPerformance(wind.rotorDiameter, wind.ratedWindSpeed)
-          .ratedSpeedOfBlades,
-    },
     ratedTorque: {
-      ...WindElement.params.ratedTorque,
+      label: "Rated torque, kNm",
+      type: "number",
       value: (wind) =>
-        calculateDfimWindPerformance(wind.rotorDiameter, wind.ratedWindSpeed)
+        calculateWindPerformance(wind.rotorDiameter, wind.ratedWindSpeed)
           .ratedTorque,
-    },
-    ratedSpeed: {
-      ...WindElement.params.ratedSpeed,
-      value: (wind) => wind.ratedSpeedOfBlades * wind.overSpeed,
     },
   },
 };

--- a/tests/dfim-defaults.spec.ts
+++ b/tests/dfim-defaults.spec.ts
@@ -42,9 +42,7 @@ for (const topology of ["wind-gb-fc", "wind-gb-fc-tr"] as const) {
   });
 }
 
-test("DFIM matches the thesis 2.1 MW reference system", async ({
-  page,
-}) => {
+test("DFIM matches the thesis 2.1 MW reference system", async ({ page }) => {
   await page.goto("/");
   await page.getByTestId("wind").click();
   await page.getByTestId("wind-gb-fc-tr").click();

--- a/tests/wind-fc.spec.ts
+++ b/tests/wind-fc.spec.ts
@@ -18,6 +18,6 @@ test("Defaults", async ({ page }) => {
     "CU-3x003-01kV",
   );
   await expect(page.getByTestId("fconverter[0].designation")).toContainText(
-    "2Q-2L-400-15-IP2x-AC-W-6p",
+    "2Q-2L-400-11-IP2x-AC-W-6p",
   );
 });


### PR DESCRIPTION
## Summary

- replace the temporary DFIM-specific wind element with one shared turbine-driven wind model
- derive rounded direct-drive and geared defaults from the former mechanical operating points
- apply the 75 m / 12 m/s thesis reference defaults when DFIM is selected without changing the wind model
- remove model re-resolution that was only needed for switching wind element definitions
- update regression coverage and the PR #78 integration document

## Default operating points

- direct drive: 10.3 m rotor, 7.7 m/s rated wind speed, 1.2 overspeed
- geared: 56.5 m rotor, 8.5 m/s rated wind speed, 1.2 overspeed
- DFIM: 75 m rotor, 12 m/s rated wind speed, 1.2 overspeed

## Validation

- `npm run build`
  - 20 unit tests passed
  - Next.js production build passed
- focused Playwright suite for wind and DFIM
  - 6 Chromium tests passed

The corrected direct-drive shaft power selects the 11 kW converter instead of the former 15 kW unit; its existing machine and cable matches remain unchanged.