### PR TITLE
Preserve parameters when selecting motor type

### DIFF
--- a/src/model/__tests__/pr-78-integration.test.ts
+++ b/src/model/__tests__/pr-78-integration.test.ts
@@ -173,102 +173,69 @@ describe("PR #78 integration", () => {
     expect(gearboxOptions).toContain("DFIM");
   });
 
-  test("selecting DFIM replaces an unsupported converter selection", () => {
-    const model = getModel("wind-gb-fc");
-    const system = createSystem(model);
-    system.element = "emachine";
-
-    const updated = updateParam(
-      customizeModel(model, system),
-      system,
-      "type",
-      "DFIM",
-    );
-    const customized = customizeModel(model, updated);
-
-    expect(updated.input.fconverter.type).toBe(DFIMConverterType[0]);
-    expect(updated.input.fconverter.gridSideFilter).toBe("sin");
-    expect(updated.input.emachine.protection).toBe("IP54/55");
-    expect(updated.input.wind.rotorDiameter).toBe(75);
-    expect(updated.input.wind.ratedWindSpeed).toBe(12);
-    expect(updated.input.wind.ratedTorque).toBeCloseTo(939.42, 2);
-    expect(updated.input.gearbox).toMatchObject({
-      numberOfStages: 2,
-      stage1Type: "helical",
-      stage1Ratio: 8,
-      stage2Type: "helical",
-      stage2Ratio: 8,
-    });
-    expect(customized.input.fconverter.params.type.options).toEqual(
-      DFIMConverterType,
-    );
-    expect(typeof customized.input.wind.params.rotorDiameter.value).toBe(
-      "number",
-    );
-    expect(typeof customized.input.wind.params.ratedWindSpeed.value).toBe(
-      "number",
-    );
-    expect(typeof customized.input.wind.params.ratedSpeedOfBlades.value).toBe(
-      "function",
-    );
-    expect(typeof customized.input.wind.params.ratedTorque.value).toBe(
-      "function",
-    );
-  });
-
-  test("uses one turbine-driven wind model for every machine type", () => {
+  test("selecting DFIM preserves all other input parameters", () => {
     const model = getModel("wind-gb-fc");
     let system = createSystem(model);
 
-    const originalModel = customizeModel(model, system);
-    expect(typeof originalModel.input.wind.params.ratedTorque.value).toBe(
-      "function",
-    );
-    expect(typeof originalModel.input.wind.params.rotorDiameter.value).toBe(
-      "number",
-    );
-    expect(system.input.wind.rotorDiameter).toBe(56.5);
-    expect(system.input.wind.ratedWindSpeed).toBe(8.5);
-    expect(system.input.wind.powerOnShaft).toBeCloseTo(424.39, 2);
-    expect(system.input.wind.ratedTorque).toBeCloseTo(201.51, 2);
-
-    system.element = "emachine";
-    system = updateParam(originalModel, system, "type", "DFIM");
-
-    expect(system.input.wind.rotorDiameter).toBe(75);
-    expect(system.input.wind.ratedWindSpeed).toBe(12);
-    expect(system.input.wind.powerOnShaft).toBeCloseTo(2104.14, 2);
-    expect(system.input.wind.ratedTorque).toBeCloseTo(939.42, 2);
-
-    const torqueAfterSelection = system.input.wind.ratedTorque;
-    system.element = "gearbox";
-    const dfimModelAfterSelection = customizeModel(model, system);
-    system = updateParam(dfimModelAfterSelection, system, "stage1Ratio", 8);
-    expect(system.input.wind.ratedTorque).toBeCloseTo(torqueAfterSelection);
-
     system.element = "wind";
-    let dfimModel = customizeModel(model, system);
-    system = updateParam(dfimModel, system, "rotorDiameter", 75);
-    dfimModel = customizeModel(model, system);
-    system = updateParam(dfimModel, system, "ratedWindSpeed", 12);
+    system = updateParam(
+      customizeModel(model, system),
+      system,
+      "rotorDiameter",
+      60,
+    );
+    system = updateParam(
+      customizeModel(model, system),
+      system,
+      "ratedWindSpeed",
+      10,
+    );
+    system = updateParam(
+      customizeModel(model, system),
+      system,
+      "overSpeed",
+      1.3,
+    );
 
-    expect(system.input.wind.powerOnShaft).toBeCloseTo(2104.14, 2);
-    expect(system.input.wind.ratedSpeedOfBlades).toBeCloseTo(21.39, 2);
-    expect(system.input.wind.ratedTorque).toBeCloseTo(939.42, 2);
+    const inputBeforeSelection = JSON.parse(JSON.stringify(system.input));
+    system.element = "emachine";
+    system = updateParam(customizeModel(model, system), system, "type", "DFIM");
+
+    expect(system.input).toEqual({
+      ...inputBeforeSelection,
+      emachine: {
+        ...inputBeforeSelection.emachine,
+        type: "DFIM",
+      },
+    });
   });
 
   test.each(["wind-gb-fc", "wind-gb-fc-tr"] as const)(
-    "DFIM defaults produce candidates for %s",
+    "DFIM reference parameters produce candidates for %s",
     (kind) => {
       const model = getModel(kind);
-      const system = createSystem(model);
-      system.element = "emachine";
+      const updated = createSystem(
+        model,
+        (element, parameter, defaultValue) => {
+          const referenceValues: Record<string, Record<string, unknown>> = {
+            wind: { rotorDiameter: 75, ratedWindSpeed: 12 },
+            gearbox: {
+              numberOfStages: 2,
+              stage1Type: "helical",
+              stage1Ratio: 8,
+              stage2Type: "helical",
+              stage2Ratio: 8,
+            },
+            emachine: { type: "DFIM", protection: "IP54/55" },
+            fconverter: {
+              type: DFIMConverterType[0],
+              gridSideFilter: "sin",
+              machineSideFilter: "no",
+            },
+          };
 
-      const updated = updateParam(
-        customizeModel(model, system),
-        system,
-        "type",
-        "DFIM",
+          return referenceValues[element]?.[parameter] ?? defaultValue;
+        },
       );
       const emachineCandidates = updated.candidates.emachine ?? [];
       const withMachine = withCandidates({

--- a/src/model/emachine.tsx
+++ b/src/model/emachine.tsx
@@ -10,8 +10,7 @@ import {
   ProtectionParam,
 } from "./cooling-protection";
 import { Environment, EnvironmentModel } from "./environment";
-import { DFIMConverterType } from "./fconverter";
-import { SystemElement, type System } from "./system";
+import { SystemElement } from "./system";
 
 export const EMachineType = ["SCIM", "DFIM", "PMSM", "SyRM"] as const;
 export const ERatedPower = [
@@ -79,51 +78,6 @@ export const EMachineElement: SystemElement<EMachine> = {
       type: "text",
       value: "SCIM",
       options: [null, ...EMachineType],
-      update: (system, value) => {
-        if (value != "DFIM") {
-          return system;
-        }
-
-        const supportsDfimDefaults =
-          (system.kind == "wind-gb-fc" || system.kind == "wind-gb-fc-tr") &&
-          system.input.wind != null &&
-          system.input.gearbox != null;
-
-        return {
-          ...system,
-          input: {
-            ...system.input,
-            ...(supportsDfimDefaults
-              ? {
-                  wind: {
-                    ...system.input.wind,
-                    rotorDiameter: 75,
-                    ratedWindSpeed: 12,
-                    overSpeed: 1.2,
-                  },
-                  gearbox: {
-                    ...system.input.gearbox,
-                    numberOfStages: 2,
-                    stage1Type: "helical",
-                    stage1Ratio: 8,
-                    stage2Type: "helical",
-                    stage2Ratio: 8,
-                  },
-                }
-              : {}),
-            emachine: {
-              ...system.input.emachine,
-              protection: "IP54/55",
-            },
-            fconverter: {
-              ...system.input.fconverter,
-              type: DFIMConverterType[0],
-              gridSideFilter: "sin",
-              machineSideFilter: "no",
-            },
-          },
-        } as System;
-      },
     },
     ratedPower: {
       ...RatedPowerParam.ratedPower,

--- a/tests/dfim-defaults.spec.ts
+++ b/tests/dfim-defaults.spec.ts
@@ -1,14 +1,37 @@
-import { expect, test } from "@playwright/test";
+import { expect, type Page, test } from "@playwright/test";
 import { readFile } from "node:fs/promises";
 
+async function configureDfimReference(page: Page) {
+  await page.getByTestId("wind.<icon>").click();
+  await page.getByLabel("Rotor diameter, m:").fill("75");
+  await page.getByLabel("Rotor diameter, m:").press("Tab");
+  await page.getByLabel("Rated wind speed, m/s:").fill("12");
+  await page.getByLabel("Rated wind speed, m/s:").press("Tab");
+
+  await page.getByTestId("gearbox.<icon>").click();
+  await page.getByLabel("Number of stages:").selectOption("2");
+  await page.getByLabel("Stage 1 ratio:").fill("8");
+  await page.getByLabel("Stage 1 ratio:").press("Tab");
+  await page.getByLabel("Stage 2 ratio:").fill("8");
+  await page.getByLabel("Stage 2 ratio:").press("Tab");
+
+  await page.getByTestId("emachine.<icon>").click();
+  await page.getByLabel("Type:").selectOption("DFIM");
+  await page.getByLabel("Protection:").selectOption("IP54/55");
+
+  await page.getByTestId("fconverter.<icon>").click();
+  await page.getByLabel("Type:").selectOption("4Q-2L-VSC");
+}
+
 for (const topology of ["wind-gb-fc", "wind-gb-fc-tr"] as const) {
-  test(`DFIM defaults produce matches in ${topology}`, async ({ page }) => {
+  test(`DFIM reference parameters produce matches in ${topology}`, async ({
+    page,
+  }) => {
     await page.goto("/");
     await page.getByTestId("wind").click();
     await page.getByTestId(topology).click();
 
-    await page.getByTestId("emachine.<icon>").click();
-    await page.getByLabel("Type:").selectOption("DFIM");
+    await configureDfimReference(page);
 
     await expect(page.getByTestId("gearbox[0].numberOfStages")).toContainText(
       "2",
@@ -47,17 +70,8 @@ test("DFIM matches the thesis 2.1 MW reference system", async ({ page }) => {
   await page.getByTestId("wind").click();
   await page.getByTestId("wind-gb-fc-tr").click();
 
-  await page.getByTestId("emachine.<icon>").click();
-  await page.getByLabel("Type:").selectOption("DFIM");
+  await configureDfimReference(page);
   await page.getByTestId("wind.<icon>").click();
-
-  await expect(page.getByLabel("Rotor diameter, m:")).toHaveValue("75");
-  await expect(page.getByLabel("Rated wind speed, m/s:")).toHaveValue("12");
-
-  await page.getByLabel("Rotor diameter, m:").fill("75");
-  await page.getByLabel("Rotor diameter, m:").press("Tab");
-  await page.getByLabel("Rated wind speed, m/s:").fill("12");
-  await page.getByLabel("Rated wind speed, m/s:").press("Tab");
   await page.getByRole("button", { name: "More..." }).first().click();
 
   await expect(page.getByLabel("Power on shaft, kW:")).toHaveValue("2104.1");
@@ -76,8 +90,7 @@ test("DFIM export actions fit a narrow viewport", async ({ page }) => {
   await page.goto("/");
   await page.getByTestId("wind").click();
   await page.getByTestId("wind-gb-fc").click();
-  await page.getByTestId("emachine.<icon>").click();
-  await page.getByLabel("Type:").selectOption("DFIM");
+  await configureDfimReference(page);
   await page.getByTestId("emachine[0].<selected>").check();
   await page.getByTestId("fconverter[0].<selected>").check();
 
@@ -102,8 +115,7 @@ test("DFIM export actions return the requested files", async ({ page }) => {
   await page.goto("/");
   await page.getByTestId("wind").click();
   await page.getByTestId("wind-gb-fc").click();
-  await page.getByTestId("emachine.<icon>").click();
-  await page.getByLabel("Type:").selectOption("DFIM");
+  await configureDfimReference(page);
   await page.getByTestId("emachine[0].<selected>").check();
   await page.getByTestId("fconverter[0].<selected>").check();
 


### PR DESCRIPTION
## Summary
- stop motor-type selection from resetting wind, gearbox, converter, filter, and protection parameters
- add regression coverage that verifies all other system inputs are preserved
- configure DFIM reference parameters explicitly in sizing and browser tests

## Verification
- `npm run build` (19 tests passed; TypeScript and production build succeeded)
- `npx playwright test tests/dfim-defaults.spec.ts --project=chromium` (5 passed)